### PR TITLE
fix(ci): add explicit permissions to workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Resolves CodeQL alert [#1](https://github.com/andresnator/dockmarks/security/code-scanning/1) by adding explicit permissions to the CI workflow.

## Changes

- `.github/workflows/ci.yml`: added `permissions: contents: read` block at workflow level

## Why

The workflow had no explicit `GITHUB_TOKEN` permissions, inheriting default repository permissions (read-write). This violates the principle of least privilege and exposes the token if a malicious dependency is executed during the pipeline.

With `contents: read`, the token can only read code — sufficient for checkout, typecheck, tests, and build. The `upload-artifact` action uses the internal artifacts API, not the token.