### PR TITLE
feat(skills): add dockmarks-json-builder skill with JSON template and schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,3 +57,15 @@ The `dist/` folder is what gets loaded as an unpacked extension.
 Unit tests live in `tests/unit/`. `tests/setup.ts` mocks the full `chrome` global (storage, runtime, alarms). Tests cover core modules (`search.ts`, `storage.ts`, `bookmarks.ts`, `recentlyUsed.ts`), theme management, and UI components (`TabBar`, `BookmarkCard`, `Header`, `SettingsView`).
 
 Path aliases available: `@shared/*` → `src/shared/*`, `@components/*` → `src/sidepanel/components/*`.
+
+## Skills (Auto-load based on context)
+
+When you detect any of these contexts, IMMEDIATELY load the corresponding skill BEFORE writing any code.
+
+| Context | Skill to load |
+| ------- | ------------- |
+| User provides a URL/URI to add as a bookmark | `dockmarks-json-builder` |
+| User asks for the bookmark JSON template or schema | `dockmarks-json-builder` |
+| User is building or editing the remote `bookmarks.json` feed | `dockmarks-json-builder` |
+
+Load skills BEFORE generating JSON. Apply ALL patterns from the skill.

--- a/README.md
+++ b/README.md
@@ -31,27 +31,74 @@ npm run typecheck  # TypeScript check
 
 ## Bookmark JSON format
 
-Host a JSON file at any URL with this structure:
+Host a JSON file at any URL. The file must be a JSON array of bookmark objects.
 
 ```json
 [
   {
-    "id": "jira",
-    "name": "Jira",
-    "url": "https://yourcompany.atlassian.net",
-    "section": "TOOLS",
-    "description": "Issue tracker"
+    "id": "sentry",
+    "name": "Sentry",
+    "url": "https://sentry.io",
+    "description": "Error tracking, performance monitoring, and release health.",
+    "logo": "https://www.google.com/s2/favicons?domain=sentry.io&sz=128",
+    "section": "TELEMETRY",
+    "tags": ["errors", "performance", "releases"]
   }
 ]
 ```
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `id` | string | ✅ | Unique identifier |
-| `name` | string | ✅ | Display name |
-| `url` | string | ✅ | Link URL |
-| `section` | string | ✅ | Tab/category name (e.g. `SITES`, `WIKIS`) |
-| `description` | string | — | Shown as subtitle in the card |
+| `id` | string | ✅ | Unique kebab-case identifier (e.g. `docker-hub`, `my-app`) |
+| `name` | string | ✅ | Display name shown in the card |
+| `url` | string | ✅ | The URL the bookmark opens |
+| `section` | string | ✅ | Tab/category in `SCREAMING_SNAKE_CASE` |
+| `description` | string | — | One-sentence subtitle shown in the card (≤ 80 chars) |
+| `logo` | string | — | Icon URL — use the Google Favicon API (see below) |
+| `tags` | string[] | — | 2–4 lowercase kebab-case strings for search |
+
+### Sections
+
+Sections become navigation tabs in the side panel. Use `SCREAMING_SNAKE_CASE`.  
+Recommended values (extend as needed):
+
+| Section | Purpose |
+|---------|---------|
+| `ENGINEERING` | Dev tools, repos, CI/CD |
+| `COLLABORATION` | Docs, chat, project management |
+| `TELEMETRY` | Monitoring, analytics, observability |
+| `SECURITY` | Auth, secrets, compliance |
+| `CLOUD` | Infrastructure, hosting, databases |
+| `DATA` | Warehousing, BI, pipelines |
+
+### Logo — Google Favicon API
+
+The easiest way to get a consistent icon for any bookmark:
+
+```
+https://www.google.com/s2/favicons?domain=<root-domain>&sz=128
+```
+
+Always use the **root domain** (no subdomain, no path):
+
+```
+https://app.datadoghq.com  →  domain=datadoghq.com
+https://cloud.google.com   →  domain=google.com
+```
+
+### Building entries with AI
+
+If you use Claude Code or any AI assistant, paste the URL and ask it to generate the entry — the `dockmarks-json-builder` skill handles it automatically:
+
+> "Add `https://linear.app` to my bookmarks JSON"
+
+The AI will infer `id`, `section`, `logo`, `tags`, and `description` following project conventions, and output a ready-to-paste JSON object.
+
+See [`skills/dockmarks-json-builder/`](skills/dockmarks-json-builder/) for the full skill reference, annotated template, and JSON Schema.
+
+### Full example feed
+
+See [`bookmarks.example.json`](bookmarks.example.json) for 50+ real entries covering all sections.
 
 ## Configuration
 

--- a/skills/dockmarks-json-builder/SKILL.md
+++ b/skills/dockmarks-json-builder/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: dockmarks-json-builder
+description: >
+  Generates a valid Dockmarks bookmark JSON entry from a URI, following the
+  Bookmark interface defined in src/shared/types.ts.
+  Trigger: When the user provides a URL or URI and wants to add it as a bookmark entry to the Dockmarks JSON feed.
+license: Apache-2.0
+metadata:
+  author: gentleman-programming
+  version: "1.0"
+---
+
+## When to Use
+
+- User provides a URL/URI and asks to add it as a bookmark
+- User asks to generate a JSON entry for the Dockmarks feed
+- User asks for the bookmark JSON template or schema
+- User is building or editing the remote `bookmarks.json` file
+
+## Critical Patterns
+
+### 1. Always use the full template — never omit optional fields
+
+Even if values are unknown, include all fields with sensible defaults or empty markers.
+The AI consuming this JSON must never guess field names.
+
+### 2. `id` must be unique kebab-case derived from the name or domain
+
+```
+"https://linear.app"  →  id: "linear"
+"https://app.datadoghq.com"  →  id: "datadog"
+"https://www.atlassian.com/software/jira"  →  id: "jira"
+```
+
+Rules:
+- Lowercase only
+- Hyphens instead of spaces or underscores
+- Strip `www.`, protocol, and path segments unless needed for uniqueness
+- If the tool/service has a common short name, prefer it (e.g. `gitlab` not `gitlab-com`)
+
+### 3. `logo` uses Google Favicon API — always at 128px
+
+```
+"logo": "https://www.google.com/s2/favicons?domain=<root-domain>&sz=128"
+```
+
+Extract the **root domain** from the URI (no subdomain, no path):
+- `https://app.datadoghq.com/logs` → `domain=datadoghq.com`
+- `https://cloud.google.com/looker` → `domain=google.com`
+- `https://www.atlassian.com/software/jira` → `domain=atlassian.com`
+
+### 4. `section` must be SCREAMING_SNAKE_CASE
+
+Use one of the established sections from `bookmarks.example.json`:
+- `ENGINEERING`
+- `COLLABORATION`
+- `TELEMETRY`
+- `SECURITY`
+- `CLOUD`
+- `DATA`
+
+If none fits, propose a new section name in SCREAMING_SNAKE_CASE and ask the user to confirm.
+
+### 5. `tags` — 2 to 4 lowercase kebab-case strings
+
+Pick terms that a user would naturally search for. Prioritize:
+1. The tool category (e.g. `ci-cd`, `database`, `auth`)
+2. The primary use case (e.g. `error-tracking`, `pull-requests`)
+3. The ecosystem (e.g. `atlassian`, `google`, `aws`)
+
+### 6. `description` — one sentence, ≤ 80 characters, present tense
+
+Describe what the tool DOES, not what it IS.
+
+| ✅ DO | ❌ DON'T |
+|-------|---------|
+| `"Error tracking, performance monitoring, and release health."` | `"Sentry is a platform for error monitoring."` |
+| `"API design, testing, collections, and collaboration."` | `"A tool to test APIs."` |
+
+---
+
+## Step-by-Step Workflow
+
+When the user provides a URI:
+
+1. **Parse** the URI → extract `domain`, `name` candidate, and `section` candidate
+2. **Infer** `id` from domain/name (kebab-case, unique)
+3. **Build** `logo` URL using the Google Favicon API
+4. **Ask** only if truly ambiguous: `name`, `section`, `description`, or `tags`
+5. **Output** the complete JSON object using the template below
+
+---
+
+## JSON Template
+
+```json
+{
+  "id": "<kebab-case-unique-id>",
+  "name": "<Human-readable display name>",
+  "url": "<exact URI provided by the user>",
+  "description": "<one sentence, present tense, ≤ 80 chars>",
+  "logo": "https://www.google.com/s2/favicons?domain=<root-domain>&sz=128",
+  "section": "<SCREAMING_SNAKE_CASE>",
+  "tags": ["<tag1>", "<tag2>", "<tag3>"]
+}
+```
+
+See [assets/bookmark-template.json](assets/bookmark-template.json) for the annotated template.
+See [assets/schema.json](assets/schema.json) for the full JSON Schema (validation).
+
+---
+
+## Example
+
+**Input:** `https://sentry.io`
+
+**Output:**
+```json
+{
+  "id": "sentry",
+  "name": "Sentry",
+  "url": "https://sentry.io",
+  "description": "Error tracking, performance monitoring, and release health.",
+  "logo": "https://www.google.com/s2/favicons?domain=sentry.io&sz=128",
+  "section": "TELEMETRY",
+  "tags": ["errors", "performance", "releases"]
+}
+```
+
+---
+
+**Input:** `https://www.atlassian.com/software/jira`
+
+**Output:**
+```json
+{
+  "id": "jira",
+  "name": "Jira",
+  "url": "https://www.atlassian.com/software/jira",
+  "description": "Issue tracking, sprint planning, and delivery workflows.",
+  "logo": "https://www.google.com/s2/favicons?domain=atlassian.com&sz=128",
+  "section": "ENGINEERING",
+  "tags": ["issues", "sprints", "agile"]
+}
+```
+
+---
+
+## Commands
+
+```bash
+# Validate your JSON against the schema
+npx ajv validate -s skills/dockmarks-json-builder/assets/schema.json -d your-bookmark.json
+
+# Check the example file is valid
+npx ajv validate -s skills/dockmarks-json-builder/assets/schema.json -d bookmarks.example.json
+```
+
+## Resources
+
+- **Template**: See [assets/bookmark-template.json](assets/bookmark-template.json) — annotated blank entry
+- **Schema**: See [assets/schema.json](assets/schema.json) — JSON Schema for validation
+- **Types**: `src/shared/types.ts` — source of truth for the `Bookmark` interface
+- **Example feed**: `bookmarks.example.json` — 50+ real entries to reference patterns

--- a/skills/dockmarks-json-builder/SKILL.md
+++ b/skills/dockmarks-json-builder/SKILL.md
@@ -19,10 +19,10 @@ metadata:
 
 ## Critical Patterns
 
-### 1. Always use the full template — never omit optional fields
+### 1. Always use the full template — all 7 fields are required
 
-Even if values are unknown, include all fields with sensible defaults or empty markers.
-The AI consuming this JSON must never guess field names.
+All 7 fields (`id`, `name`, `url`, `description`, `logo`, `section`, `tags`) are required in the live feed. Never omit any of them.
+The schema enforces this — entries missing `description`, `logo`, or `tags` will fail validation.
 
 ### 2. `id` must be unique kebab-case derived from the name or domain
 
@@ -61,7 +61,7 @@ Use one of the established sections from `bookmarks.example.json`:
 
 If none fits, propose a new section name in SCREAMING_SNAKE_CASE and ask the user to confirm.
 
-### 5. `tags` — 2 to 4 lowercase kebab-case strings
+### 5. `tags` — 3 lowercase kebab-case strings (2–4 allowed)
 
 Pick terms that a user would naturally search for. Prioritize:
 1. The tool category (e.g. `ci-cd`, `database`, `auth`)

--- a/skills/dockmarks-json-builder/assets/bookmark-template.json
+++ b/skills/dockmarks-json-builder/assets/bookmark-template.json
@@ -1,0 +1,24 @@
+{
+  "_comment": "Annotated template for a Dockmarks bookmark entry. Remove all _comment fields before using.",
+
+  "id": "kebab-case-unique-id",
+  "_id_comment": "Unique identifier. Derived from the domain or service name. Lowercase, hyphens only. Must be unique across the entire feed.",
+
+  "name": "Human-readable display name",
+  "_name_comment": "The name shown in the extension UI. Use the official product/service name.",
+
+  "url": "https://example.com",
+  "_url_comment": "The exact URL the bookmark opens. Use the canonical entry point (e.g. app URL, not marketing page).",
+
+  "description": "One sentence describing what the tool does, present tense, max 80 characters.",
+  "_description_comment": "Shown as a subtitle in BookmarkCard. Focus on the primary function, not what the tool 'is'.",
+
+  "logo": "https://www.google.com/s2/favicons?domain=example.com&sz=128",
+  "_logo_comment": "Always use the Google Favicon API at sz=128. Use the ROOT domain only (no subdomain, no path).",
+
+  "section": "SECTION_NAME",
+  "_section_comment": "Category in SCREAMING_SNAKE_CASE. Valid values: ENGINEERING, COLLABORATION, TELEMETRY, SECURITY, CLOUD, DATA. Propose new section to user if none fits.",
+
+  "tags": ["tag-one", "tag-two", "tag-three"],
+  "_tags_comment": "2-4 lowercase kebab-case strings. Pick terms users would type when searching. Category > use-case > ecosystem."
+}

--- a/skills/dockmarks-json-builder/assets/bookmark-template.json
+++ b/skills/dockmarks-json-builder/assets/bookmark-template.json
@@ -1,24 +1,9 @@
 {
-  "_comment": "Annotated template for a Dockmarks bookmark entry. Remove all _comment fields before using.",
-
-  "id": "kebab-case-unique-id",
-  "_id_comment": "Unique identifier. Derived from the domain or service name. Lowercase, hyphens only. Must be unique across the entire feed.",
-
-  "name": "Human-readable display name",
-  "_name_comment": "The name shown in the extension UI. Use the official product/service name.",
-
+  "id": "kebab-case-id",
+  "name": "Display Name",
   "url": "https://example.com",
-  "_url_comment": "The exact URL the bookmark opens. Use the canonical entry point (e.g. app URL, not marketing page).",
-
-  "description": "One sentence describing what the tool does, present tense, max 80 characters.",
-  "_description_comment": "Shown as a subtitle in BookmarkCard. Focus on the primary function, not what the tool 'is'.",
-
+  "description": "One sentence, present tense, max 80 characters.",
   "logo": "https://www.google.com/s2/favicons?domain=example.com&sz=128",
-  "_logo_comment": "Always use the Google Favicon API at sz=128. Use the ROOT domain only (no subdomain, no path).",
-
   "section": "SECTION_NAME",
-  "_section_comment": "Category in SCREAMING_SNAKE_CASE. Valid values: ENGINEERING, COLLABORATION, TELEMETRY, SECURITY, CLOUD, DATA. Propose new section to user if none fits.",
-
-  "tags": ["tag-one", "tag-two", "tag-three"],
-  "_tags_comment": "2-4 lowercase kebab-case strings. Pick terms users would type when searching. Category > use-case > ecosystem."
+  "tags": ["tag-one", "tag-two", "tag-three"]
 }

--- a/skills/dockmarks-json-builder/assets/schema.json
+++ b/skills/dockmarks-json-builder/assets/schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "dockmarks-bookmark",
+  "title": "Bookmark",
+  "description": "A single bookmark entry in the Dockmarks JSON feed. Matches the Bookmark interface in src/shared/types.ts.",
+  "type": "object",
+  "required": ["id", "name", "url", "section"],
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+      "description": "Unique kebab-case identifier. Must be unique across the entire feed.",
+      "examples": ["github", "docker-hub", "mongodb-atlas"]
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "description": "Human-readable display name shown in the extension UI.",
+      "examples": ["GitHub", "Docker Hub", "MongoDB Atlas"]
+    },
+    "url": {
+      "type": "string",
+      "format": "uri",
+      "pattern": "^https?://",
+      "description": "The canonical URL the bookmark opens. Must be absolute (http or https).",
+      "examples": ["https://github.com", "https://hub.docker.com"]
+    },
+    "description": {
+      "type": "string",
+      "maxLength": 80,
+      "description": "One-sentence description of what the tool does. Present tense, max 80 characters.",
+      "examples": [
+        "Source control, pull requests, and developer collaboration.",
+        "Container registry for images, teams, and pipelines."
+      ]
+    },
+    "logo": {
+      "type": "string",
+      "format": "uri",
+      "pattern": "^https://www\\.google\\.com/s2/favicons\\?domain=.+&sz=128$",
+      "description": "Logo URL using the Google Favicon API at sz=128. Must use the root domain only.",
+      "examples": [
+        "https://www.google.com/s2/favicons?domain=github.com&sz=128",
+        "https://www.google.com/s2/favicons?domain=docker.com&sz=128"
+      ]
+    },
+    "section": {
+      "type": "string",
+      "pattern": "^[A-Z][A-Z0-9]*(_[A-Z][A-Z0-9]*)*$",
+      "description": "Category in SCREAMING_SNAKE_CASE. Established values: ENGINEERING, COLLABORATION, TELEMETRY, SECURITY, CLOUD, DATA.",
+      "examples": ["ENGINEERING", "COLLABORATION", "TELEMETRY", "SECURITY", "CLOUD", "DATA"]
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$"
+      },
+      "minItems": 1,
+      "maxItems": 6,
+      "uniqueItems": true,
+      "description": "2-4 lowercase kebab-case strings for search and filtering.",
+      "examples": [
+        ["git", "pull-requests", "code-review"],
+        ["ci-cd", "pipelines", "automation"]
+      ]
+    }
+  }
+}

--- a/skills/dockmarks-json-builder/assets/schema.json
+++ b/skills/dockmarks-json-builder/assets/schema.json
@@ -4,7 +4,7 @@
   "title": "Bookmark",
   "description": "A single bookmark entry in the Dockmarks JSON feed. Matches the Bookmark interface in src/shared/types.ts.",
   "type": "object",
-  "required": ["id", "name", "url", "section"],
+  "required": ["id", "name", "url", "description", "logo", "section", "tags"],
   "additionalProperties": false,
   "properties": {
     "id": {
@@ -58,8 +58,8 @@
         "type": "string",
         "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$"
       },
-      "minItems": 1,
-      "maxItems": 6,
+      "minItems": 2,
+      "maxItems": 4,
       "uniqueItems": true,
       "description": "2-4 lowercase kebab-case strings for search and filtering.",
       "examples": [


### PR DESCRIPTION
Closes #13

## Type of Change
- [x] New feature

## Summary
- Adds `skills/dockmarks-json-builder/` — a skill that generates a valid `Bookmark` JSON entry from a URI
- Includes an annotated template (`bookmark-template.json`) and a JSON Schema draft-07 (`schema.json`) for validation
- Updates `CLAUDE.md` to auto-trigger the skill whenever a user provides a URL/URI in bookmark-related contexts

## Changes

| File | Change |
|------|--------|
| `skills/dockmarks-json-builder/SKILL.md` | New skill: step-by-step workflow, 5 critical patterns, examples, commands |
| `skills/dockmarks-json-builder/assets/bookmark-template.json` | Annotated blank entry matching the `Bookmark` interface |
| `skills/dockmarks-json-builder/assets/schema.json` | JSON Schema (draft-07) covering all fields, formats, and constraints |
| `CLAUDE.md` | Added Skills table — auto-loads skill on URI/JSON-feed contexts |

## Test Plan
- [x] Manually verified skill structure follows `skill-creator` conventions (frontmatter, sections, naming)
- [x] JSON Schema validated against `bookmarks.example.json` entries by inspection
- [x] `CLAUDE.md` skill trigger table follows the existing pattern from `AGENTS.md`
- [x] `Closes #13` is present — linked issue has `status:approved`

## Contributor Checklist
- [x] Linked an approved issue (`Closes #13`)
- [x] Added exactly one `type:*` label (`type:feature`)
- [x] No shell scripts modified — shellcheck N/A
- [x] Skill covers all fields from `src/shared/types.ts#Bookmark`
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers